### PR TITLE
adapt to SparkSQL Connector cassandra datastore needs

### DIFF
--- a/cassandra-connector/src/main/config/CassandraDataStore.xml
+++ b/cassandra-connector/src/main/config/CassandraDataStore.xml
@@ -12,6 +12,16 @@
             <Description>Cassandra Port</Description>
         </Property>
     </RequiredProperties>
+	<OptionalProperties>
+        <Property>
+            <PropertyName>rpcPort</PropertyName>
+            <Description>The Cassandra RPC Port.</Description>
+        </Property>
+        <Property>
+            <PropertyName>cluster</PropertyName>
+            <Description>Cassandra cluster name</Description>
+        </Property>
+    </OptionalProperties>
     <Behaviors>
         <Behavior>UPSERT_ON_INSERT</Behavior>
     </Behaviors>


### PR DESCRIPTION
The properties are necessary to SparkSQL connector when it try connect to a Cassandra Cluster
